### PR TITLE
Fixes editing game while not having an image

### DIFF
--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -102,7 +102,15 @@ pub fn edit_in_db(
     let mut connection =
         Connection::open(paths::get_pbp().join("library.db")).map_err(|e| e.to_string())?;
     // copy new image to location
-    let image_path = copy_image(&image).unwrap_or(Path::new("").to_path_buf());
+    let image_path = if image == "None" {
+        "None".to_string()
+    } else {
+        copy_image(&image)
+            .unwrap_or(Path::new("").to_path_buf())
+            .display()
+            .to_string()
+    };
+
     let query =
         "UPDATE games SET name = ?, executable = ?, description = ?, image = ? WHERE id = ?";
 
@@ -113,7 +121,7 @@ pub fn edit_in_db(
             name,
             executable,
             description,
-            image_path.display().to_string(),
+            image_path,
             id
         ],
     )


### PR DESCRIPTION
**What changes were made?**
Fixes an bug that would crash PBP if trying to edit a game with no image set

**This fixes an issue?**
This doesn't fix an issue on the Issues page, but this fixes a bug

**Does this code introduce any issues or warnings?**
This doesn't generate any warnings

**Were you able to test on multiple platforms?**
- [x] Linux
- [ ] Windows
- [ ] macOS

